### PR TITLE
change type of OperatingPeriod to OperatingPeriod_VersionStructure in…

### DIFF
--- a/src/main/java/org/entur/netex/index/api/NetexEntitiesIndex.java
+++ b/src/main/java/org/entur/netex/index/api/NetexEntitiesIndex.java
@@ -1,44 +1,7 @@
 package org.entur.netex.index.api;
 
 import com.google.common.collect.Multimap;
-import org.rutebanken.netex.model.Authority;
-import org.rutebanken.netex.model.Branding;
-import org.rutebanken.netex.model.CompositeFrame;
-import org.rutebanken.netex.model.DatedServiceJourney;
-import org.rutebanken.netex.model.DayType;
-import org.rutebanken.netex.model.DayTypeAssignment;
-import org.rutebanken.netex.model.DestinationDisplay;
-import org.rutebanken.netex.model.FareZone;
-import org.rutebanken.netex.model.FlexibleLine;
-import org.rutebanken.netex.model.FlexibleStopPlace;
-import org.rutebanken.netex.model.GroupOfLines;
-import org.rutebanken.netex.model.GroupOfStopPlaces;
-import org.rutebanken.netex.model.GroupOfTariffZones;
-import org.rutebanken.netex.model.JourneyPattern;
-import org.rutebanken.netex.model.Line;
-import org.rutebanken.netex.model.Network;
-import org.rutebanken.netex.model.Notice;
-import org.rutebanken.netex.model.NoticeAssignment;
-import org.rutebanken.netex.model.OperatingDay;
-import org.rutebanken.netex.model.OperatingPeriod;
-import org.rutebanken.netex.model.Operator;
-import org.rutebanken.netex.model.Parking;
-import org.rutebanken.netex.model.PassengerStopAssignment;
-import org.rutebanken.netex.model.Quay;
-import org.rutebanken.netex.model.ResourceFrame;
-import org.rutebanken.netex.model.Route;
-import org.rutebanken.netex.model.RoutePoint;
-import org.rutebanken.netex.model.ScheduledStopPoint;
-import org.rutebanken.netex.model.ServiceCalendarFrame;
-import org.rutebanken.netex.model.ServiceFrame;
-import org.rutebanken.netex.model.ServiceJourney;
-import org.rutebanken.netex.model.ServiceJourneyInterchange;
-import org.rutebanken.netex.model.ServiceLink;
-import org.rutebanken.netex.model.SiteFrame;
-import org.rutebanken.netex.model.StopPlace;
-import org.rutebanken.netex.model.TariffZone;
-import org.rutebanken.netex.model.TimetableFrame;
-import org.rutebanken.netex.model.TopographicPlace;
+import org.rutebanken.netex.model.*;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
@@ -163,7 +126,7 @@ public interface NetexEntitiesIndex {
      * Get an entity index of OperatingPeriod
      * @return
      */
-    NetexEntityIndex<OperatingPeriod> getOperatingPeriodIndex();
+    NetexEntityIndex<OperatingPeriod_VersionStructure> getOperatingPeriodIndex();
 
     /**
      * Get an entity index of Operator

--- a/src/main/java/org/entur/netex/index/impl/NetexEntitiesIndexImpl.java
+++ b/src/main/java/org/entur/netex/index/impl/NetexEntitiesIndexImpl.java
@@ -6,44 +6,7 @@ import com.google.common.collect.Multimaps;
 import org.entur.netex.index.api.NetexEntityIndex;
 import org.entur.netex.index.api.NetexEntitiesIndex;
 import org.entur.netex.index.api.VersionedNetexEntityIndex;
-import org.rutebanken.netex.model.Authority;
-import org.rutebanken.netex.model.Branding;
-import org.rutebanken.netex.model.CompositeFrame;
-import org.rutebanken.netex.model.DatedServiceJourney;
-import org.rutebanken.netex.model.DayType;
-import org.rutebanken.netex.model.DayTypeAssignment;
-import org.rutebanken.netex.model.DestinationDisplay;
-import org.rutebanken.netex.model.FareZone;
-import org.rutebanken.netex.model.FlexibleLine;
-import org.rutebanken.netex.model.FlexibleStopPlace;
-import org.rutebanken.netex.model.GroupOfLines;
-import org.rutebanken.netex.model.GroupOfStopPlaces;
-import org.rutebanken.netex.model.GroupOfTariffZones;
-import org.rutebanken.netex.model.JourneyPattern;
-import org.rutebanken.netex.model.Line;
-import org.rutebanken.netex.model.Network;
-import org.rutebanken.netex.model.Notice;
-import org.rutebanken.netex.model.NoticeAssignment;
-import org.rutebanken.netex.model.OperatingDay;
-import org.rutebanken.netex.model.OperatingPeriod;
-import org.rutebanken.netex.model.Operator;
-import org.rutebanken.netex.model.Parking;
-import org.rutebanken.netex.model.PassengerStopAssignment;
-import org.rutebanken.netex.model.Quay;
-import org.rutebanken.netex.model.ResourceFrame;
-import org.rutebanken.netex.model.Route;
-import org.rutebanken.netex.model.RoutePoint;
-import org.rutebanken.netex.model.ScheduledStopPoint;
-import org.rutebanken.netex.model.ServiceCalendarFrame;
-import org.rutebanken.netex.model.ServiceFrame;
-import org.rutebanken.netex.model.ServiceJourney;
-import org.rutebanken.netex.model.ServiceJourneyInterchange;
-import org.rutebanken.netex.model.ServiceLink;
-import org.rutebanken.netex.model.SiteFrame;
-import org.rutebanken.netex.model.StopPlace;
-import org.rutebanken.netex.model.TariffZone;
-import org.rutebanken.netex.model.TimetableFrame;
-import org.rutebanken.netex.model.TopographicPlace;
+import org.rutebanken.netex.model.*;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
@@ -74,7 +37,7 @@ public class NetexEntitiesIndexImpl implements NetexEntitiesIndex {
     public final NetexEntityIndex<Notice> noticeById;
     public final NetexEntityIndex<NoticeAssignment> noticeAssignmentById;
     public final NetexEntityIndex<OperatingDay> operatingDayById;
-    public final NetexEntityIndex<OperatingPeriod> operatingPeriodById;
+    public final NetexEntityIndex<OperatingPeriod_VersionStructure> operatingPeriodById;
     public final NetexEntityIndex<Operator> operatorsById;
     public final NetexEntityIndex<Branding> brandingsById;
     public final VersionedNetexEntityIndex<Quay> quayById;
@@ -256,7 +219,7 @@ public class NetexEntitiesIndexImpl implements NetexEntitiesIndex {
     }
 
     @Override
-    public NetexEntityIndex<OperatingPeriod> getOperatingPeriodIndex() {
+    public NetexEntityIndex<OperatingPeriod_VersionStructure> getOperatingPeriodIndex() {
         return operatingPeriodById;
     }
 

--- a/src/main/java/org/entur/netex/loader/parser/ServiceCalendarFrameParser.java
+++ b/src/main/java/org/entur/netex/loader/parser/ServiceCalendarFrameParser.java
@@ -28,7 +28,7 @@ class ServiceCalendarFrameParser extends NetexParser<ServiceCalendarFrame_Versio
     private static final Logger LOG = LoggerFactory.getLogger(ServiceCalendarFrameParser.class);
 
     private final Collection<DayType> dayTypes = new ArrayList<>();
-    private final Collection<OperatingPeriod> operatingPeriods = new ArrayList<>();
+    private final Collection<OperatingPeriod_VersionStructure> operatingPeriods = new ArrayList<>();
     private final Collection<OperatingDay> operatingDays = new ArrayList<>();
     private final Multimap<String, DayTypeAssignment> dayTypeAssignmentByDayTypeId = ArrayListMultimap.create();
 
@@ -89,9 +89,7 @@ class ServiceCalendarFrameParser extends NetexParser<ServiceCalendarFrame_Versio
     private void parseOperatingPeriods(OperatingPeriodsInFrame_RelStructure element) {
         if(element == null) { return; }
 
-        for (OperatingPeriod_VersionStructure p : element.getOperatingPeriodOrUicOperatingPeriod()) {
-            operatingPeriods.add((OperatingPeriod) p);
-        }
+        operatingPeriods.addAll(element.getOperatingPeriodOrUicOperatingPeriod());
     }
 
     private void parseOperatingDays(OperatingDaysInFrame_RelStructure element) {


### PR DESCRIPTION
… order to fix failed cast of UICOperatingPeriod

I have dug into Issue #90 and noticed that it was caused by incompatible types being parsed.

This PR shows a possible solution to fix the problem. But I have almost no idea of the underlying data structure, so better only use it as a rough template for a proper solution.