### PR TITLE
fix: concurrency issue during update of versioned entities index

### DIFF
--- a/src/main/java/org/entur/netex/index/impl/VersionedNetexEntityIndexImpl.java
+++ b/src/main/java/org/entur/netex/index/impl/VersionedNetexEntityIndexImpl.java
@@ -5,8 +5,10 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import org.entur.netex.index.api.VersionedNetexEntityIndex;
 import org.rutebanken.netex.model.EntityInVersionStructure;
+import org.rutebanken.netex.model.EntityStructure;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -53,19 +55,19 @@ public class VersionedNetexEntityIndexImpl<V extends EntityInVersionStructure> i
 
     @Override
     public void putAll(Collection<V> entities) {
-        entities.stream()
-                .collect(Collectors.groupingBy(V::getId))
-                .forEach(this::replaceValues);
+        Map<String, List<V>> entityMap = entities.stream()
+                .collect(Collectors.groupingBy(V::getId));
+
+        entityMap.forEach(map::replaceValues);
+
+        latestMap.putAll(entityMap.keySet().stream()
+                .map(id -> latestVersionedElementIn(map.get(id)))
+                .collect(Collectors.toMap(EntityStructure::getId, e -> e)));
     }
 
     @Override
     public void remove(String id) {
         map.removeAll(id);
         latestMap.remove(id);
-    }
-
-    private void replaceValues(String id, Collection<V> newValues) {
-        map.replaceValues(id, newValues);
-        latestMap.put(id, latestVersionedElementIn(newValues));
     }
 }

--- a/src/main/java/org/entur/netex/index/impl/VersionedNetexEntityIndexImpl.java
+++ b/src/main/java/org/entur/netex/index/impl/VersionedNetexEntityIndexImpl.java
@@ -56,8 +56,7 @@ public class VersionedNetexEntityIndexImpl<V extends EntityInVersionStructure> i
     public void putAll(Collection<V> entities) {
         entities.stream()
                 .collect(Collectors.groupingBy(V::getId))
-                .forEach(map::replaceValues);
-        populateLatestMap();
+                .forEach(this::replaceValues);
     }
 
     @Override
@@ -66,12 +65,8 @@ public class VersionedNetexEntityIndexImpl<V extends EntityInVersionStructure> i
         latestMap.remove(id);
     }
 
-    private void populateLatestMap() {
-        synchronized (latestMap) {
-            latestMap.clear();
-            latestMap.putAll(map.keySet().stream()
-                    .map(id -> latestVersionedElementIn(map.get(id)))
-                    .collect(Collectors.toMap(EntityStructure::getId, e -> e)));
-        }
+    private void replaceValues(String id, Collection<V> newValues) {
+        map.replaceValues(id, newValues);
+        latestMap.put(id, latestVersionedElementIn(newValues));
     }
 }

--- a/src/main/java/org/entur/netex/index/impl/VersionedNetexEntityIndexImpl.java
+++ b/src/main/java/org/entur/netex/index/impl/VersionedNetexEntityIndexImpl.java
@@ -5,7 +5,6 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import org.entur.netex.index.api.VersionedNetexEntityIndex;
 import org.rutebanken.netex.model.EntityInVersionStructure;
-import org.rutebanken.netex.model.EntityStructure;
 
 import java.util.Collection;
 import java.util.Map;


### PR DESCRIPTION
Solves #99 

A concurrent call to get the latest version could get empty result during update, because the latest map is cleared before it is repopulated.

~~Perhaps not the best solution, but for now, synchronized access to the map during update will fix the issue.~~ Instead of repopulating the whole map, only update entities actually added.

Also, single put and remove can update the map directly.

~~_Note that this has potentially worse performance for large collections._~~