### PR TITLE
Add null check for CompositeFrame frames

### DIFF
--- a/src/main/java/org/entur/netex/loader/parser/NetexDocumentParser.java
+++ b/src/main/java/org/entur/netex/loader/parser/NetexDocumentParser.java
@@ -105,6 +105,10 @@ public class NetexDocumentParser {
     // Declare some ugly types to prevent obstructing the reading later...
     Collection<JAXBElement<? extends Common_VersionFrameStructure>> frames;
 
+    if (frame.getFrames() == null) {
+      LOG.debug("Composite frame {} has no frames, skipping", frame.getId());
+      return;
+    }
     frames = frame.getFrames().getCommonFrame();
 
     for (JAXBElement<? extends Common_VersionFrameStructure> it : frames) {


### PR DESCRIPTION
This PR adds a null check for the frames field in CompositeFrame to safely handle cases where a CompositeFrame has a null frames property. At Dat.mobility, we frequently parse NeTEx data containing CompositeFrames with empty "frames" fields, which currently causes errors in the parser.

This fix allows us to use the netex-parser-java library as a regular Maven dependency without needing a forked version just to handle this edge case. The change is minimal but improves robustness when dealing with real-world NeTEx data that may not strictly follow the schema.