### PR TITLE
Add support for XML stream reader

### DIFF
--- a/src/main/java/org/entur/netex/XmlStreamReaderFactory.java
+++ b/src/main/java/org/entur/netex/XmlStreamReaderFactory.java
@@ -1,0 +1,11 @@
+package org.entur.netex;
+
+import java.io.InputStream;
+import javax.xml.stream.XMLStreamReader;
+
+/**
+ * Factory for XMLStreamReader. Concrete implementations can be used to ignore elements within the XML document
+ */
+public interface XmlStreamReaderFactory {
+  XMLStreamReader createXmlStreamReader(InputStream inputStream);
+}

--- a/src/main/java/org/entur/netex/loader/NetexXmlParser.java
+++ b/src/main/java/org/entur/netex/loader/NetexXmlParser.java
@@ -5,6 +5,7 @@ import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 import java.io.InputStream;
+import javax.xml.stream.XMLStreamReader;
 import org.rutebanken.netex.model.PublicationDeliveryStructure;
 
 /** Simple wrapper to perform typesafe xml parsing and simple error handling. */
@@ -26,6 +27,20 @@ public class NetexXmlParser {
     JAXBElement<PublicationDeliveryStructure> root =
       (JAXBElement<PublicationDeliveryStructure>) unmarshaller.unmarshal(
         stream
+      );
+
+    return root.getValue();
+  }
+
+  /**
+   * Parse an input stream and return the root document type for the given xml file (stream).
+   */
+  public PublicationDeliveryStructure parseXmlDoc(XMLStreamReader reader)
+    throws JAXBException {
+    @SuppressWarnings("unchecked")
+    JAXBElement<PublicationDeliveryStructure> root =
+      (JAXBElement<PublicationDeliveryStructure>) unmarshaller.unmarshal(
+        reader
       );
 
     return root.getValue();


### PR DESCRIPTION
Add support for reading a NeTEx document through an XML stream reader (StAX).
This gives the possibility to filter out XML elements through a custom XML stream reader to reduce memory footprint.