### PR TITLE
Build with Maven Central

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - name: Copy maven settings
         run: |
-          wget https://raw.githubusercontent.com/entur/ror-maven-settings/master/.m2/settings.xml -O .github/workflows/settings.xml
+          wget https://raw.githubusercontent.com/entur/ror-maven-settings/master/.m2/settings_release_maven_central.xml -O .github/workflows/settings.xml
       - uses: actions/setup-java@v4
         with:
           java-version: 17.0.13
@@ -68,7 +68,7 @@ jobs:
           fetch-depth: 0
       - name: Copy maven settings
         run: |
-          wget https://raw.githubusercontent.com/entur/ror-maven-settings/master/.m2/settings.xml -O .github/workflows/settings.xml
+          wget https://raw.githubusercontent.com/entur/ror-maven-settings/master/.m2/settings_release_maven_central.xml -O .github/workflows/settings.xml
       - uses: actions/setup-java@v4
         with:
           java-version: 17.0.13


### PR DESCRIPTION
This PR ensures that the build pipeline does not depend on the  Entur internal Maven repository 