### PR TITLE
chore(deps): update codecov/codecov-action from v5 to v6

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,6 +28,6 @@ jobs:
       - name: Run maven build
         run: mvn package -PprettierCheck -Dprettier.nodePath=node -Dprettier.npmPath=npm
       - name: codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
            files: ./target/site/jacoco/jacoco.xml


### PR DESCRIPTION
## Summary
- Update `codecov/codecov-action` from v5 to v6

Replaces Renovate PR #283.

## Test plan
- [ ] CI workflows pass with the updated action version