### PR TITLE
fix(release): skip JReleaser git tag (SSH) and restore SNAPSHOT version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.entur</groupId>
     <artifactId>netex-parser-java</artifactId>
-    <version>4.0.1</version>
+    <version>4.0.2-SNAPSHOT</version>
 
     <name>netex-java-parser</name>
     <description>Library for parsing NeTEx files and looking up entities in an index.</description>
@@ -285,7 +285,7 @@
                         </deploy>
                         <release>
                             <github>
-                                <skipTag>false</skipTag>
+                                <skipTag>true</skipTag>
                                 <skipRelease>true</skipRelease>
                             </github>
                         </release>


### PR DESCRIPTION
The publish job checks out via the SSH deploy key so the version-bump commit can bypass the master ruleset. That makes `origin` an SSH remote, so JReleaser's JGit tag push fails with `this.sch is null` (JGit has no SSH transport in that runner) even though the artifact uploads to Maven Central successfully.

Set skipTag=true: `jreleaser:full-release` still deploys to Maven Central and now skips the git tag (skipRelease was already true), so the publish step succeeds.

Also bump 4.0.1 -> 4.0.2-SNAPSHOT: the 4.0.1 release left master on a release version because the "Push Next Version" step was skipped after the tag push failed.