### PR TITLE
Add parser support for parking opening hours (AvailabilityCondition)

### DIFF
--- a/src/main/java/org/entur/netex/index/api/NetexEntitiesIndex.java
+++ b/src/main/java/org/entur/netex/index/api/NetexEntitiesIndex.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Map;
 import org.rutebanken.netex.model.Authority;
+import org.rutebanken.netex.model.AvailabilityCondition;
 import org.rutebanken.netex.model.Block;
 import org.rutebanken.netex.model.Branding;
 import org.rutebanken.netex.model.CompositeFrame;
@@ -296,6 +297,13 @@ public interface NetexEntitiesIndex {
    * @return
    */
   Multimap<String, Parking> getParkingsByParentSiteRefIndex();
+
+  /**
+   * Get a Multimap of AvailabilityConditions by Parking id.
+   * Populated from {@code validityConditions} on each parsed Parking.
+   * @return
+   */
+  Multimap<String, AvailabilityCondition> getAvailabilityConditionsByParkingIdIndex();
 
   /**
    * Get an entity index of FareZone

--- a/src/main/java/org/entur/netex/index/impl/NetexEntitiesIndexImpl.java
+++ b/src/main/java/org/entur/netex/index/impl/NetexEntitiesIndexImpl.java
@@ -12,6 +12,7 @@ import org.entur.netex.index.api.NetexEntitiesIndex;
 import org.entur.netex.index.api.NetexEntityIndex;
 import org.entur.netex.index.api.VersionedNetexEntityIndex;
 import org.rutebanken.netex.model.Authority;
+import org.rutebanken.netex.model.AvailabilityCondition;
 import org.rutebanken.netex.model.Block;
 import org.rutebanken.netex.model.Branding;
 import org.rutebanken.netex.model.CompositeFrame;
@@ -102,6 +103,7 @@ public class NetexEntitiesIndexImpl implements NetexEntitiesIndex {
   public final VersionedNetexEntityIndex<FareZone> fareZoneById;
   public final VersionedNetexEntityIndex<GroupOfTariffZones> groupOfTariffZonesById;
   public final Multimap<String, Parking> parkingsByParentSiteRef;
+  public final Multimap<String, AvailabilityCondition> availabilityConditionsByParkingId;
 
   // Relations between entities - The Netex XML sometimes rely on the
   // nested structure of the XML document, rater than explicit references.
@@ -178,6 +180,8 @@ public class NetexEntitiesIndexImpl implements NetexEntitiesIndex {
     this.vehicleScheduleFrames = new HashSet<>();
     this.timetableFrames = new HashSet<>();
     this.parkingsByParentSiteRef =
+      Multimaps.synchronizedListMultimap(ArrayListMultimap.create());
+    this.availabilityConditionsByParkingId =
       Multimaps.synchronizedListMultimap(ArrayListMultimap.create());
   }
 
@@ -439,5 +443,10 @@ public class NetexEntitiesIndexImpl implements NetexEntitiesIndex {
   @Override
   public Multimap<String, Parking> getParkingsByParentSiteRefIndex() {
     return parkingsByParentSiteRef;
+  }
+
+  @Override
+  public Multimap<String, AvailabilityCondition> getAvailabilityConditionsByParkingIdIndex() {
+    return availabilityConditionsByParkingId;
   }
 }

--- a/src/main/java/org/entur/netex/loader/parser/SiteFrameParser.java
+++ b/src/main/java/org/entur/netex/loader/parser/SiteFrameParser.java
@@ -43,6 +43,9 @@ class SiteFrameParser extends NetexParser<Site_VersionFrameStructure> {
   private final Multimap<String, Parking> parkingsByStopPlaceId =
     ArrayListMultimap.create();
 
+  private final Multimap<String, AvailabilityCondition> availabilityConditionsByParkingId =
+    ArrayListMultimap.create();
+
   @Override
   public void parse(Site_VersionFrameStructure frame) {
     if (frame.getStopPlaces() != null) {
@@ -119,6 +122,9 @@ class SiteFrameParser extends NetexParser<Site_VersionFrameStructure> {
     netexIndex.getQuayIndex().putAll(quays.values());
     netexIndex.getStopPlaceIdByQuayIdIndex().putAll(stopPlaceIdByQuayId);
     netexIndex.getParkingsByParentSiteRefIndex().putAll(parkingsByStopPlaceId);
+    netexIndex
+      .getAvailabilityConditionsByParkingIdIndex()
+      .putAll(availabilityConditionsByParkingId);
     netexIndex.getGroupOfTariffZonesIndex().putAll(groupsOfTariffZones);
   }
 
@@ -166,6 +172,18 @@ class SiteFrameParser extends NetexParser<Site_VersionFrameStructure> {
     for (Parking parking : parkingList) {
       parkings.add(parking);
       parkingsByStopPlaceId.put(parking.getParentSiteRef().getRef(), parking);
+      if (parking.getValidityConditions() != null) {
+        for (Object obj : parking
+          .getValidityConditions()
+          .getValidityConditionRefOrValidBetweenOrValidityCondition_()) {
+          if (
+            obj instanceof JAXBElement<?> jaxb &&
+            jaxb.getValue() instanceof AvailabilityCondition ac
+          ) {
+            availabilityConditionsByParkingId.put(parking.getId(), ac);
+          }
+        }
+      }
     }
   }
 

--- a/src/test/java/org/entur/netex/TestParkingAvailabilityConditions.java
+++ b/src/test/java/org/entur/netex/TestParkingAvailabilityConditions.java
@@ -1,0 +1,74 @@
+package org.entur.netex;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Collection;
+import org.entur.netex.index.api.NetexEntitiesIndex;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.rutebanken.netex.model.AvailabilityCondition;
+
+class TestParkingAvailabilityConditions {
+
+  private static NetexEntitiesIndex index;
+
+  @BeforeAll
+  static void init() {
+    try {
+      NetexParser parser = new NetexParser();
+      File file = new File(
+        "src/test/resources/ParkingWithAvailabilityConditions.xml"
+      );
+      index = parser.parse(Files.newInputStream(file.toPath()));
+    } catch (Exception e) {
+      Assertions.fail(e.getMessage(), e);
+    }
+  }
+
+  @Test
+  void parkingWithAvailabilityConditionsIsIndexedByParkingId() {
+    Collection<AvailabilityCondition> conditions = index
+      .getAvailabilityConditionsByParkingIdIndex()
+      .get("FSR:Parking:1");
+    Assertions.assertEquals(2, conditions.size());
+  }
+
+  @Test
+  void availabilityConditionOpenDayHasCorrectFields() {
+    AvailabilityCondition openCondition = index
+      .getAvailabilityConditionsByParkingIdIndex()
+      .get("FSR:Parking:1")
+      .stream()
+      .filter(ac -> "FSR:AvailabilityCondition:1".equals(ac.getId()))
+      .findFirst()
+      .orElseThrow();
+
+    Assertions.assertTrue(openCondition.isIsAvailable());
+    Assertions.assertNotNull(openCondition.getDayTypes());
+    Assertions.assertFalse(
+      openCondition.getDayTypes().getDayTypeRefOrDayType_().isEmpty()
+    );
+  }
+
+  @Test
+  void availabilityConditionClosedDayHasIsAvailableFalse() {
+    AvailabilityCondition closedCondition = index
+      .getAvailabilityConditionsByParkingIdIndex()
+      .get("FSR:Parking:1")
+      .stream()
+      .filter(ac -> "FSR:AvailabilityCondition:2".equals(ac.getId()))
+      .findFirst()
+      .orElseThrow();
+
+    Assertions.assertFalse(closedCondition.isIsAvailable());
+  }
+
+  @Test
+  void parkingWithoutAvailabilityConditionsReturnsEmptyCollection() {
+    Collection<AvailabilityCondition> conditions = index
+      .getAvailabilityConditionsByParkingIdIndex()
+      .get("FSR:Parking:2");
+    Assertions.assertTrue(conditions.isEmpty());
+  }
+}

--- a/src/test/resources/ParkingWithAvailabilityConditions.xml
+++ b/src/test/resources/ParkingWithAvailabilityConditions.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:ns2="http://www.opengis.net/gml/3.2" version="1">
+    <PublicationTimestamp>2026-07-21T10:00:00</PublicationTimestamp>
+    <ParticipantRef>FSR</ParticipantRef>
+    <dataObjects>
+        <SiteFrame version="1" id="FSR:SiteFrame:1">
+            <stopPlaces>
+                <StopPlace version="1" id="FSR:StopPlace:1">
+                    <Name lang="fin">Test Stop</Name>
+                    <Centroid>
+                        <Location>
+                            <Longitude>25.0</Longitude>
+                            <Latitude>60.0</Latitude>
+                        </Location>
+                    </Centroid>
+                </StopPlace>
+            </stopPlaces>
+            <parkings>
+                <Parking version="1" id="FSR:Parking:1">
+                    <validityConditions>
+                        <AvailabilityCondition version="1" id="FSR:AvailabilityCondition:1">
+                            <IsAvailable>true</IsAvailable>
+                            <dayTypes>
+                                <DayTypeRef ref="FSR:DayType:BusinessDay"/>
+                            </dayTypes>
+                            <timebands>
+                                <Timeband version="1" id="FSR:Timeband:1">
+                                    <StartTime>06:00:00</StartTime>
+                                    <EndTime>22:00:00</EndTime>
+                                </Timeband>
+                            </timebands>
+                        </AvailabilityCondition>
+                        <AvailabilityCondition version="1" id="FSR:AvailabilityCondition:2">
+                            <IsAvailable>false</IsAvailable>
+                            <dayTypes>
+                                <DayTypeRef ref="FSR:DayType:Sunday"/>
+                            </dayTypes>
+                        </AvailabilityCondition>
+                    </validityConditions>
+                    <Name lang="fin">Test Parking</Name>
+                    <Centroid>
+                        <Location>
+                            <Longitude>25.0</Longitude>
+                            <Latitude>60.0</Latitude>
+                        </Location>
+                    </Centroid>
+                    <ParkingType>urbanParking</ParkingType>
+                    <ParkingLayout>openSpace</ParkingLayout>
+                    <ParentSiteRef ref="FSR:StopPlace:1"/>
+                </Parking>
+                <Parking version="1" id="FSR:Parking:2">
+                    <Name lang="fin">Parking without opening hours</Name>
+                    <Centroid>
+                        <Location>
+                            <Longitude>25.1</Longitude>
+                            <Latitude>60.1</Latitude>
+                        </Location>
+                    </Centroid>
+                    <ParkingType>urbanParking</ParkingType>
+                    <ParkingLayout>openSpace</ParkingLayout>
+                    <ParentSiteRef ref="FSR:StopPlace:1"/>
+                </Parking>
+            </parkings>
+        </SiteFrame>
+    </dataObjects>
+</PublicationDelivery>


### PR DESCRIPTION
## Summary

Add a dedicated index for `AvailabilityCondition` elements found inside `Parking.validityConditions`. This allows downstream consumers to look up parking opening hours by parking id without having to manually traverse the raw JAXB object.

### Changes

- `NetexEntitiesIndex`: new `getAvailabilityConditionsByParkingIdIndex()` method returning `Multimap<String, AvailabilityCondition>`
- `NetexEntitiesIndexImpl`: backing `Multimap` field and getter implementation
- `SiteFrameParser`: extracts `AvailabilityCondition` entries from each parking's `validityConditions` list during parsing
- New test fixture and test class covering parkings with/without availability conditions

### Motivation

Parking opening hours are modelled as `AvailabilityCondition` elements in `validityConditions`. Without this change they were parsed into the raw `Parking` JAXB object but not indexed, so downstream consumers had no convenient query path.